### PR TITLE
worker: Cleanup pending path if build fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: install build test lint vet fmt clean
 
 install: fmt vet test
+	# TODO: also install cli
 	go install -v
 
 test:

--- a/end_to_end_test.go
+++ b/end_to_end_test.go
@@ -130,8 +130,11 @@ func TestBuildCoalescing(t *testing.T) {
 
 // cliBuildJob uses the CLI binary to issue a new job request to the server.
 // It returns an error if the request could not be issued.
+//
+// NOTE: The CLI binary is expected to be present in the working
+// directory where the tests are ran from.
 func cliBuildJob(args ...string) (string, error) {
-	args = append([]string{"mistry-cli", "build", "--host", host, "--port", port, "--target", target, "--transport-user", username}, args...)
+	args = append([]string{"./mistry-cli", "build", "--host", host, "--port", port, "--target", target, "--transport-user", username}, args...)
 	out, err := utils.RunCmd(args)
 
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -27,6 +27,8 @@ func NewServer(addr string, logger *log.Logger) *Server {
 }
 
 // handleNewJob receives requests for new jobs and schedules their building.
+// TODO: also return a JSON report an errors (ideally a BuildResult with Err
+// populated)
 func (s *Server) handleNewJob(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "POST" {
 		http.Error(w, "Expected POST, got "+r.Method, http.StatusMethodNotAllowed)

--- a/testdata/projects/failed-build-cleanup/Dockerfile
+++ b/testdata/projects/failed-build-cleanup/Dockerfile
@@ -1,0 +1,3 @@
+FROM debian:stretch
+
+INVALIDCOMMAND

--- a/testdata/projects/failed-build-cleanup/docker-entrypoint.sh
+++ b/testdata/projects/failed-build-cleanup/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+cat params/foo > artifacts/out.txt

--- a/testdata/projects/failed-build-cleanup/docker-entrypoint.sh
+++ b/testdata/projects/failed-build-cleanup/docker-entrypoint.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-
-cat params/foo > artifacts/out.txt


### PR DESCRIPTION
Notice that we update the Work function to use named returns to capture
the defer errors.