### PR TITLE
Clean all pending builds on mistry boot time

### DIFF
--- a/mistry_test.go
+++ b/mistry_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/skroutz/mistry/utils"
+)
+
+func TestPruneZombieBuilds(t *testing.T) {
+	project := "hanging-pending"
+	cmdOut, err := cliBuildJob("--project", project)
+	if err != nil {
+		t.Fatalf("Error output: %s, err: %v", cmdOut, err)
+	}
+	path := filepath.Join(cfg.BuildPath, project, "pending")
+	_, err = utils.RunCmd(curfs.Create(filepath.Join(path, "foo")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = utils.RunCmd(curfs.Create(filepath.Join(path, "bar")))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = PruneZombieBuilds(curfs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	hangingPendingBuilds, err := ioutil.ReadDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(hangingPendingBuilds) != 0 {
+		t.Fatalf("Expected to have cleaned up all zombie pending builds, found %d", len(hangingPendingBuilds))
+	}
+}

--- a/testdata/projects/hanging-pending/Dockerfile
+++ b/testdata/projects/hanging-pending/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:stretch
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/testdata/projects/hanging-pending/docker-entrypoint.sh
+++ b/testdata/projects/hanging-pending/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+touch artifacts/out.txt
+
+exit 0


### PR DESCRIPTION
This fixes the following bug:

- a job {"project": "hanging-pending"} hasn't finished building and the service shuts down
- when the service restarts the build is still pending but hasn't resumed building, it will stay pending forever

The result is that the client is not able to fetch the jobs results or request another one (with the same parameters) since the service _sees_ the build as pending.

We solve this by pruning all pending builds on the service boot time.