### PR TITLE
Use project image in job ID seeding

### DIFF
--- a/end_to_end_test.go
+++ b/end_to_end_test.go
@@ -22,7 +22,7 @@ func TestSimpleBuild(t *testing.T) {
 }
 
 func TestUnknownProject(t *testing.T) {
-	expected := "Unknown project"
+	expected := "Unknown project 'Idontexist'"
 
 	cmdOut, err := cliBuildJob("--project", "Idontexist")
 	if !strings.Contains(cmdOut, expected) {

--- a/job.go
+++ b/job.go
@@ -177,3 +177,9 @@ func (j *Job) StartContainer(ctx context.Context, c *docker.Client, out io.Write
 
 	return result.State.ExitCode, nil
 }
+
+func (j *Job) String() string {
+	return fmt.Sprintf(
+		"project=%s params=%s group=%s id=%s",
+		j.Project, j.Params, j.Group, j.ID[:7])
+}

--- a/job.go
+++ b/job.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"crypto/sha256"
@@ -17,6 +16,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
+	"github.com/skroutz/mistry/utils"
 )
 
 type Job struct {
@@ -40,15 +40,40 @@ type Job struct {
 	// (pending)
 	BuildLogPath        string
 	BuildResultFilePath string
+
+	// docker image tar
+	ImageTar []byte
 }
 
 func NewJob(project string, params map[string]string, group string) (*Job, error) {
+	var err error
+
 	if project == "" {
 		return nil, errors.New("No project given")
 	}
 
 	j := new(Job)
+	j.Project = project
+	j.Group = group
+	j.Params = params
+	j.ProjectPath = filepath.Join(cfg.ProjectsPath, j.Project)
+	j.RootBuildPath = filepath.Join(cfg.BuildPath, j.Project)
 
+	if j.Group == "" {
+		j.LatestBuildPath = filepath.Join(j.RootBuildPath, "latest")
+	} else {
+		j.LatestBuildPath = filepath.Join(j.RootBuildPath, "groups", j.Group)
+	}
+
+	j.ImageTar, err = utils.Tar(j.ProjectPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("Unknown project '%s'", j.Project)
+		}
+		return nil, err
+	}
+
+	// compute ID
 	keys := []string{}
 	for k := range params {
 		keys = append(keys, k)
@@ -59,22 +84,13 @@ func NewJob(project string, params map[string]string, group string) (*Job, error
 	for _, v := range keys {
 		seed += v + params[v]
 	}
+	seed += string(j.ImageTar)
+
 	j.ID = fmt.Sprintf("%x", sha256.Sum256([]byte(seed)))
-	j.Project = project
-	j.Group = group
-	j.Params = params
-	j.RootBuildPath = filepath.Join(cfg.BuildPath, j.Project)
+
 	j.PendingBuildPath = filepath.Join(j.RootBuildPath, "pending", j.ID)
 	j.ReadyBuildPath = filepath.Join(j.RootBuildPath, "ready", j.ID)
 	j.ReadyDataPath = filepath.Join(j.ReadyBuildPath, DataDir)
-
-	if j.Group == "" {
-		j.LatestBuildPath = filepath.Join(j.RootBuildPath, "latest")
-	} else {
-		j.LatestBuildPath = filepath.Join(j.RootBuildPath, "groups", j.Group)
-	}
-
-	j.ProjectPath = filepath.Join(cfg.ProjectsPath, j.Project)
 	j.BuildLogPath = filepath.Join(j.PendingBuildPath, BuildLogFname)
 	j.BuildResultFilePath = filepath.Join(j.PendingBuildPath, BuildResultFname)
 
@@ -82,59 +98,10 @@ func NewJob(project string, params map[string]string, group string) (*Job, error
 }
 
 func (j *Job) BuildImage(ctx context.Context, c *docker.Client, out io.Writer) error {
-	var buf bytes.Buffer
-	tw := tar.NewWriter(&buf)
-
-	walkFn := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if !info.Mode().IsRegular() {
-			return nil
-		}
-
-		hdr, err := tar.FileInfoHeader(info, info.Name())
-		if err != nil {
-			return err
-		}
-
-		err = tw.WriteHeader(hdr)
-		if err != nil {
-			return err
-		}
-
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-
-		_, err = io.Copy(tw, f)
-		if err != nil {
-			return err
-		}
-
-		err = f.Close()
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}
-
-	err := filepath.Walk(j.ProjectPath, walkFn)
-	if err != nil {
-		return err
-	}
-
-	err = tw.Close()
-	if err != nil {
-		return err
-	}
-
 	buildArgs := make(map[string]*string)
 	buildArgs["uid"] = &cfg.UID
 	buildOpts := types.ImageBuildOptions{Tags: []string{j.Project}, BuildArgs: buildArgs, NetworkMode: "host"}
-	resp, err := c.ImageBuild(context.Background(), &buf, buildOpts)
+	resp, err := c.ImageBuild(context.Background(), bytes.NewBuffer(j.ImageTar), buildOpts)
 	if err != nil {
 		return err
 	}

--- a/job_test.go
+++ b/job_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestJobID(t *testing.T) {
+	project := "job-id-seeding"
+	params := map[string]string{"foo": "bar"}
+	group := "zzz"
+
+	j1, err := NewJob(project, params, group)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	j2, err := NewJob(project, params, group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEq(j1.ID, j2.ID, t)
+
+	// params seeding
+	j3, err := NewJob(project, make(map[string]string), group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNotEq(j1.ID, j3.ID, t)
+
+	// group seeding
+	j4, err := NewJob(project, params, "c")
+	assertNotEq(j1.ID, j4.ID, t)
+
+	// project seeding (new empty file)
+	path := filepath.Join("testdata", "projects", project, "foo")
+	os.Remove(path) // in case there's a leftover from a previous run
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+	j5, err := NewJob(project, params, group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNotEq(j1.ID, j5.ID, t)
+
+	// project seeding (new non-empty file)
+	_, err = f.Write([]byte("foo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	j6, err := NewJob(project, params, group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertNotEq(j5.ID, j6.ID, t)
+	assertNotEq(j1.ID, j6.ID, t)
+
+	err = f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/testdata/projects/job-id-seeding/Dockerfile
+++ b/testdata/projects/job-id-seeding/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:stretch
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/testdata/projects/job-id-seeding/docker-entrypoint.sh
+++ b/testdata/projects/job-id-seeding/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+sleep 2
+
+echo "coalescing!" > artifacts/out.txt


### PR DESCRIPTION
This fixes the following bug:

- a job `{"project": "foo", "params": {"foo":"bar"}}` is built successfully
- a change to the Dockerfile (or any other file, for that matter) of project
  "foo" Dockerfile is applied
  - another job, identical to the first one arrives

Expected: the job should run after the new image is built (since the
Dockerfile changed).

Previous behavior: the cached results from the first execution were
returned, without actually re-building the image and re-running the job.

We solve this by using the project's contents (filenames and contents)
as a seed when generating the job ID.