### PR TITLE
client: Pass --delete to rsync

### DIFF
--- a/client/transport.go
+++ b/client/transport.go
@@ -27,5 +27,5 @@ func (ts Rsync) Copy(user, host, project, src, dst string) []string {
 	}
 	src = src[idx:]
 
-	return []string{"rsync", "-rtlp", fmt.Sprintf("%s@%s::%s/%s", user, host, module, src), dst}
+	return []string{"rsync", "--delete", "-rtlp", fmt.Sprintf("%s@%s::%s/%s", user, host, module, src), dst}
 }


### PR DESCRIPTION
With this change, we delete extraneous files from the destination dir.

The produced command is: 
```shell
rsync --delete -rtlp apostergiou@localhost::mistry/simple/ready/c8d654f58623063cb55e0790890ad5aada1235be093ced09f7057e366b2de264/data/artifacts/* /tmp/foo

# client request

$ ./mistry-cli build --host localhost --port 8462 --project simple --group $RANDOM --target /tmp/foo --transport rsync -- --flavor=$RANDOM --x=$RANDOM
```