### PR TITLE
Fix logic to determine job directory bootstraping

### DIFF
--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -19,6 +19,18 @@ func TestSimpleBuild(t *testing.T) {
 	}
 }
 
+func TestNonGroupSubsequentInvocation(t *testing.T) {
+	cmdout, cmderr, err := cliBuildJob("--project", "bootstrap-twice")
+	if err != nil {
+		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
+	}
+	// invoke the 2nd job with different params to trigger the bug
+	cmdout, cmderr, err = cliBuildJob("--project", "bootstrap-twice", "--", "--foo=zxc")
+	if err != nil {
+		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
+	}
+}
+
 func TestUnknownProject(t *testing.T) {
 	expected := "Unknown project 'Idontexist'"
 

--- a/cmd/mistryd/testdata/projects/bootstrap-twice/Dockerfile
+++ b/cmd/mistryd/testdata/projects/bootstrap-twice/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:stretch
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/cmd/mistryd/testdata/projects/bootstrap-twice/docker-entrypoint.sh
+++ b/cmd/mistryd/testdata/projects/bootstrap-twice/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+touch artifacts/out.txt
+
+exit 0


### PR DESCRIPTION
* cleanup logic: only job invocations with a group and a previous
build copy the previous build, the rest create new directories
* don't do unneccessary symlink lookup for non-group jobs
* add test case

- [x] update logic
- [x] factor out some functions