### PR TITLE
Parse image build json logs

### DIFF
--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -19,6 +19,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/mount"
 	docker "github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/jsonmessage"
 	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/skroutz/mistry/pkg/filesystem"
 	"github.com/skroutz/mistry/pkg/types"
@@ -134,7 +135,7 @@ func (j *Job) BuildImage(ctx context.Context, uid string, c *docker.Client, out 
 	}
 	defer resp.Body.Close()
 
-	_, err = io.Copy(out, resp.Body)
+	err = jsonmessage.DisplayJSONMessagesStream(resp.Body, out, 0, false, nil)
 	if err != nil {
 		return types.ErrImageBuild{Image: j.Image, Err: err}
 	}

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -187,12 +187,12 @@ func (j *Job) StartContainer(ctx context.Context, cfg *Config, c *docker.Client,
 	if err != nil {
 		return 0, err
 	}
+	defer logs.Close()
 
 	_, err = stdcopy.StdCopy(out, out, logs)
 	if err != nil {
 		return 0, err
 	}
-	logs.Close()
 
 	var result struct {
 		State struct {


### PR DESCRIPTION
Parse the JSON log output from the image build process into human readable logs, using the same method used in the docker CLI

https://github.com/moby/moby/blob/89658bed64c2a8fe05a978e5b87dbec409d57a0f/cli/command/image/build.go#L319

Also contains a small unrelated fix for closing the container logs file descriptor on error

Closes #37