### PR TITLE
Change filesystem Create and Clone, and Btrfs.Remove behavior

### DIFF
--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -308,18 +308,14 @@ func (j *Job) CloneSrcPath(log *log.Logger) string {
 // been partially or fully created and cleanup is required
 func (j *Job) BootstrapBuildDir(fs filesystem.FileSystem, log *log.Logger) (bool, error) {
 	shouldCleanup := false
-	var cmd []string
+	var err error
 
 	cloneSrc := j.CloneSrcPath(log)
 
 	if cloneSrc == "" {
-		cmd = fs.Create(j.PendingBuildPath)
+		err = fs.Create(j.PendingBuildPath)
 	} else {
-		cmd = fs.Clone(cloneSrc, j.PendingBuildPath)
-	}
-	out, err := utils.RunCmd(cmd)
-	if out != "" {
-		log.Println(out)
+		err = fs.Clone(cloneSrc, j.PendingBuildPath)
 	}
 	if err != nil {
 		return shouldCleanup, workErr("could not create pending build path", err)

--- a/cmd/mistryd/mistryd_test.go
+++ b/cmd/mistryd/mistryd_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/skroutz/mistry/pkg/filesystem"
 	"github.com/skroutz/mistry/pkg/types"
-	"github.com/skroutz/mistry/pkg/utils"
 )
 
 var (
@@ -128,11 +127,11 @@ func TestPruneZombieBuilds(t *testing.T) {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
 	}
 	path := filepath.Join(testcfg.BuildPath, project, "pending")
-	_, err = utils.RunCmd(testcfg.FileSystem.Create(filepath.Join(path, "foo")))
+	err = testcfg.FileSystem.Create(filepath.Join(path, "foo"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = utils.RunCmd(testcfg.FileSystem.Create(filepath.Join(path, "bar")))
+	err = testcfg.FileSystem.Create(filepath.Join(path, "bar"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/filesystem/btrfs/btrfs.go
+++ b/pkg/filesystem/btrfs/btrfs.go
@@ -2,6 +2,7 @@ package btrfs
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/skroutz/mistry/pkg/filesystem"
 	"github.com/skroutz/mistry/pkg/utils"
@@ -13,19 +14,27 @@ import (
 type Btrfs struct{}
 
 func init() {
-	filesystem.List["btrfs"] = Btrfs{}
+	filesystem.Registry["btrfs"] = Btrfs{}
 }
 
-func (fs Btrfs) Create(path string) []string {
-	return []string{"btrfs", "subvolume", "create", path}
+func (fs Btrfs) Create(path string) error {
+	return runCmd([]string{"btrfs", "subvolume", "create", path})
 }
 
-func (fs Btrfs) Clone(src, dst string) []string {
-	return []string{"btrfs", "subvolume", "snapshot", src, dst}
+func (fs Btrfs) Clone(src, dst string) error {
+	return runCmd([]string{"btrfs", "subvolume", "snapshot", src, dst})
 }
 
 func (fs Btrfs) Remove(path string) error {
-	out, err := utils.RunCmd([]string{"btrfs", "subvolume", "delete", path})
+	_, err := os.Stat(path)
+	if err == nil {
+		return runCmd([]string{"btrfs", "subvolume", "delete", path})
+	}
+	return nil
+}
+
+func runCmd(args []string) error {
+	out, err := utils.RunCmd(args)
 	if err != nil {
 		return fmt.Errorf("%s (%s)", err, out)
 	}

--- a/pkg/filesystem/filesystem.go
+++ b/pkg/filesystem/filesystem.go
@@ -4,27 +4,29 @@ import (
 	"fmt"
 )
 
-var List = make(map[string]FileSystem)
+// Registry maps the filesystem name to its implementation
+var Registry = make(map[string]FileSystem)
 
+// FileSystem defines a few basic filesystem operations
 type FileSystem interface {
-	// Create returns a command followed by its arguments, that will
-	// create path as a directory.
-	Create(path string) []string
+	// Create creates a new directory in the given path.
+	Create(path string) error
 
-	// Clone returns a command followed by its arguments, that will
-	// clone src to dst.
-	Clone(src, dst string) []string
+	// Clone copies the src directory and its contents to the dst.
+	Clone(src, dst string) error
 
 	// Remove removes path and its children.
+	// Implementors should not return an error when the path does not
+	// exist.
 	Remove(path string) error
 }
 
 // Get returns the registered filesystem denoted by s. If it doesn't exist,
 // an error is returned.
 func Get(s string) (FileSystem, error) {
-	fs, ok := List[s]
+	fs, ok := Registry[s]
 	if !ok {
-		return nil, fmt.Errorf("unknown filesystem '%s' (%v)", s, List)
+		return nil, fmt.Errorf("unknown filesystem '%s' (%v)", s, Registry)
 	}
 	return fs, nil
 }

--- a/pkg/filesystem/plainfs/plainfs.go
+++ b/pkg/filesystem/plainfs/plainfs.go
@@ -1,9 +1,11 @@
 package plainfs
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/skroutz/mistry/pkg/filesystem"
+	"github.com/skroutz/mistry/pkg/utils"
 )
 
 // PlainFS implements the FileSystem interface. It uses plain `cp` and `mkdir`
@@ -11,17 +13,24 @@ import (
 type PlainFS struct{}
 
 func init() {
-	filesystem.List["plain"] = PlainFS{}
+	filesystem.Registry["plain"] = PlainFS{}
 }
 
-func (fs PlainFS) Create(path string) []string {
-	return []string{"mkdir", path}
+// Create creates a new directory at path
+func (fs PlainFS) Create(path string) error {
+	return os.Mkdir(path, 0755)
 }
 
-func (fs PlainFS) Clone(src, dst string) []string {
-	return []string{"cp", "-r", src, dst}
+// Clone recursively copies the contents of src to dst
+func (fs PlainFS) Clone(src, dst string) error {
+	out, err := utils.RunCmd([]string{"cp", "-r", src, dst})
+	if err != nil {
+		return fmt.Errorf("%s (%s)", err, out)
+	}
+	return nil
 }
 
+// Remove deletes the path and all its contents
 func (fs PlainFS) Remove(path string) error {
 	return os.RemoveAll(path)
 }


### PR DESCRIPTION
* Btrfs.Remove no longer returns an error if the path does not exist, similar to the Plainfs behavior. The interface for Remove was updated to document that
* Create and Clone now execute the operation instead of returning a
command string array
* rename filesystem.List to filesystem.Registry 