### PR TITLE
Trigger a build asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ### Added
 
+- Asynchronous job scheduling [[#61](https://github.com/skroutz/mistry/pull/61)]
 - Web view [[#17](https://github.com/skroutz/mistry/pull/17)]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,21 +91,45 @@ using the JSON API directly. We recommended using `mistry` whenever possible
 (although it may occassionally lag behind the server in terms of
 supported features).
 
-**Scheduling a new job and fetching the artifacts:**
-```shell
-$ mistry --project foo
+#### Client
+
+##### Schedule a new job, wait for completion, and fetch the artifacts
+
+```sh
+$ mistry build --project foo --target .
 ```
-This will place the artifacts and the current working directory.
+This will place the artifacts and the target directory.
+
+##### Schedule a new job without waiting
+
+```sh
+$ mistry build --project foo --async
+```
 
 See `mistry build -h` for more options.
 
-**Scheduling a new job without fetching the artifacts**:
-``` shell
-$ curl -H 'Content-Type: application/json' -d '{"project": "foo"}' localhost:8462/jobs
+#### HTTP Endpoints
+
+##### Schedule a new job
+
+```sh
+$ curl -X POST /jobs \
+    -H 'Accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -d '{"project": "foo"}' 
 ```
 
-
-
+```js
+{
+    "Params": {"foo": "xzv"}, 
+    "Path": "<artifact path>",
+    "Cached": true,
+    "Coalesced": false,
+    "ExitCode": 0,
+    "Err": null,
+    "TransportMethod": "rsync"
+}
+```
 
 
 ### Web view

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -62,6 +62,11 @@ type Job struct {
 	State  string
 }
 
+// NewJobFromRequest returns a new Job from the JobRequest
+func NewJobFromRequest(jr types.JobRequest, cfg *Config) (*Job, error) {
+	return NewJob(jr.Project, jr.Params, jr.Group, cfg)
+}
+
 // NewJob returns a new Job for the given project. project and cfg cannot be
 // empty.
 func NewJob(project string, params types.Params, group string, cfg *Config) (*Job, error) {
@@ -221,6 +226,7 @@ func (j *Job) String() string {
 		j.Project, j.Params, j.Group, j.ID[:7])
 }
 
+// MarshalJSON serializes the Job to JSON
 func (j *Job) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		ID        string        `json:"id"`
@@ -239,6 +245,8 @@ func (j *Job) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// UnmarshalJSON deserializes JSON data and updates the Job
+// with them
 func (j *Job) UnmarshalJSON(data []byte) error {
 	jData := &struct {
 		ID        string `json:"id"`

--- a/cmd/mistryd/main.go
+++ b/cmd/mistryd/main.go
@@ -57,6 +57,7 @@ const (
 	// Docker images/containers created by mistry.
 	ImgCntPrefix = "mistry-"
 
+	// DateFmt the date format
 	DateFmt = "Mon, 02 Jan 2006 15:04:05"
 )
 

--- a/cmd/mistryd/project_queue.go
+++ b/cmd/mistryd/project_queue.go
@@ -2,15 +2,18 @@ package main
 
 import "sync"
 
+// ProjectQueue provides a goroutine-safe mutex per project
 type ProjectQueue struct {
 	mu sync.Mutex
 	p  map[string]*sync.Mutex
 }
 
+// NewProjectQueue creates a new empty struct
 func NewProjectQueue() *ProjectQueue {
 	return &ProjectQueue{p: make(map[string]*sync.Mutex)}
 }
 
+// Lock locks the project's mutex
 func (q *ProjectQueue) Lock(project string) {
 	q.mu.Lock()
 	plock, ok := q.p[project]
@@ -22,6 +25,7 @@ func (q *ProjectQueue) Lock(project string) {
 	plock.Lock()
 }
 
+// Unlock unlocks the project's mutex
 func (q *ProjectQueue) Unlock(project string) {
 	q.mu.Lock()
 	q.p[project].Unlock()

--- a/cmd/mistryd/server_test.go
+++ b/cmd/mistryd/server_test.go
@@ -155,3 +155,16 @@ func TestHandleShowJob(t *testing.T) {
 		t.Errorf("Expeced body to contain %v, got %v", expected, string(body))
 	}
 }
+
+func TestNewJobAsync(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/jobs?async", strings.NewReader("{\"project\": \"simple\"}"))
+	server.srv.Handler.ServeHTTP(rec, req)
+	resp := rec.Result()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("Error in reading response body: %s", err)
+	}
+	assertEq(resp.StatusCode, 201, t)
+	assertEq(string(body), "", t)
+}


### PR DESCRIPTION
Add a `mistry build --no-wait` flag that triggers a build and exits without waiting

* add a new client flag
* update the server endpoint to accept `POST /jobs?async`, returns an empty 201 response on success
* update README and CLI docs

Some small random improvements
* use {{.HelpName}}  and {{.Name}} in help templates to avoid hardcoding command names
* add some comments to exported functions to stop go fmt complains
* ~embed the JobRequest into the Job to avoid field declaration duplication~

Closes #15 