### PR TITLE
rerun failed builds instead of using their cached result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ### Changed
 
+- Failed jobs are no longer cached [[#62](https://github.com/skroutz/mistry/pull/62)]
 - **[BREAKING]** client/server: Client and server binaries are renamed to "mistryd" and "mistry" respectively.
   Also project is now go-gettable. [[abbfb58](https://github.com/skroutz/mistry/commit/abbfb58d5a2aaf3eaebf9408d81ec7d459326416)]
 - client: default host is now 0.0.0.0

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -346,3 +346,8 @@ func (j *Job) BootstrapBuildDir(fs filesystem.FileSystem, log *log.Logger) (bool
 	}
 	return shouldCleanup, nil
 }
+
+// RemoveBuildDir removes the existing build directory
+func (j *Job) RemoveBuildDir(fs filesystem.FileSystem, log *log.Logger) error {
+	return fs.Remove(j.ReadyBuildPath)
+}

--- a/cmd/mistryd/testdata/projects/result-cache-exitcode/Dockerfile
+++ b/cmd/mistryd/testdata/projects/result-cache-exitcode/Dockerfile
@@ -1,8 +1,0 @@
-FROM debian:stretch
-
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh
-
-WORKDIR /data
-
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/cmd/mistryd/testdata/projects/result-cache-exitcode/docker-entrypoint.sh
+++ b/cmd/mistryd/testdata/projects/result-cache-exitcode/docker-entrypoint.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-date +%S%N > artifacts/out.txt
-
-exit 33

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -35,9 +35,17 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 		if err != nil {
 			return buildInfo, err
 		}
-		buildInfo.Cached = true
-		buildInfo.ExitCode = i
-		return buildInfo, err
+		if i != 0 {
+			// previous build failed, remove its build dir to restart it
+			err = j.RemoveBuildDir(s.cfg.FileSystem, log)
+			if err != nil {
+				return buildInfo, workErr("could not remove existing failed build", err)
+			}
+		} else {
+			buildInfo.Cached = true
+			buildInfo.ExitCode = i
+			return buildInfo, err
+		}
 	} else if !os.IsNotExist(err) {
 		err = workErr("could not check for ready path", err)
 		return


### PR DESCRIPTION
Re-run "ready" jobs whose exit status is not 0. Re-running such a job means removing the existing ready folder and then proceeding as usual, i.e. creating a new pending folder etc.

Closes #45 