### PR TITLE
Add --clear-target option

### DIFF
--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -52,6 +52,7 @@ func main() {
 		verbose       bool
 		jsonResult    bool
 		noWait        bool
+		clearTarget   bool
 	)
 
 	currentUser, err := user.Current()
@@ -145,6 +146,11 @@ EXAMPLES:
 					Usage:       "the local directory where the artifacts will be saved",
 					Destination: &target,
 					Value:       ".",
+				},
+				cli.BoolFlag{
+					Name:        "clear-target",
+					Usage:       "whether to remove any previously existing files in the target directory",
+					Destination: &clearTarget,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -249,7 +255,7 @@ EXAMPLES:
 					return fmt.Errorf("Build failed with exit code %d", bi.ExitCode)
 				}
 
-				out, err := utils.RunCmd(ts.Copy(transportUser, host, project, bi.Path+"/*", target))
+				out, err := utils.RunCmd(ts.Copy(transportUser, host, project, bi.Path+"/*", target, clearTarget))
 				fmt.Println(out)
 				if err != nil {
 					return err

--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/skroutz/mistry/pkg/types"
-	"github.com/skroutz/mistry/pkg/utils"
 	"github.com/urfave/cli"
 )
 
@@ -149,7 +148,7 @@ EXAMPLES:
 				},
 				cli.BoolFlag{
 					Name:        "clear-target",
-					Usage:       "whether to remove any previously existing files in the target directory",
+					Usage:       "remove contents of the target directory before fetching artifacts",
 					Destination: &clearTarget,
 				},
 			},
@@ -255,7 +254,7 @@ EXAMPLES:
 					return fmt.Errorf("Build failed with exit code %d", bi.ExitCode)
 				}
 
-				out, err := utils.RunCmd(ts.Copy(transportUser, host, project, bi.Path+"/*", target, clearTarget))
+				out, err := ts.Copy(transportUser, host, project, bi.Path+"/*", target, clearTarget)
 				fmt.Println(out)
 				if err != nil {
 					return err

--- a/cmd/mistry/transport.go
+++ b/cmd/mistry/transport.go
@@ -2,23 +2,44 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
 type Transport interface {
-	Copy(user, host, project, src, dst string) []string
+	Copy(user, host, project, src, dst string, clearDst bool) []string
 }
 
 type Scp struct{}
 
-func (ts Scp) Copy(user, host, project, src, dst string) []string {
+func (ts Scp) Copy(user, host, project, src, dst string, clearDst bool) []string {
+	if clearDst {
+		removeDirContents(dst)
+	}
 	return []string{"scp", "-r", fmt.Sprintf("%s@%s:%s", user, host, src), dst}
+}
+
+func removeDirContents(dir string) error {
+	items, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, item := range items {
+		err = os.RemoveAll(filepath.Join(dir, item.Name()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 type Rsync struct{}
 
-func (ts Rsync) Copy(user, host, project, src, dst string) []string {
+func (ts Rsync) Copy(user, host, project, src, dst string, clearDst bool) []string {
 	module := "mistry"
 
 	idx := strings.Index(src, project)
@@ -26,6 +47,11 @@ func (ts Rsync) Copy(user, host, project, src, dst string) []string {
 		log.Fatalf("Expected '%s' to contain '%s'", src, project)
 	}
 	src = src[idx:]
+	cmd := []string{"rsync", "-rtlp"}
+	if clearDst {
+		cmd = append(cmd, "--delete")
+	}
+	cmd = append(cmd, fmt.Sprintf("%s@%s::%s/%s", user, host, module, src), dst)
 
-	return []string{"rsync", "-rtlp", fmt.Sprintf("%s@%s::%s/%s", user, host, module, src), dst}
+	return cmd
 }

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -90,7 +90,7 @@ func waitUntilExists(path string) error {
 }
 
 func TestBuildRemoveTarget(t *testing.T) {
-	// create files at the target dir
+	// create a new temp target dir
 	target, err := ioutil.TempDir("", "test-remove-target")
 	failIfError(err, t)
 	defer os.RemoveAll(target)
@@ -107,10 +107,11 @@ func TestBuildRemoveTarget(t *testing.T) {
 		failIfError(err, t)
 		f.Close()
 	}
+	cliArgs := cliDefaultArgs
+	cliArgs.target = target
 
 	// run the job with remove-target
-	cmdout, cmderr, err := cliBuildJobTarget(target, "--project", "simple", "--verbose", "--clear-target")
-	t.Logf("cli output: out: %s err: %s", cmdout, cmderr)
+	cmdout, cmderr, err := cliBuildJobArgs(cliArgs, "--project", "simple", "--verbose", "--clear-target")
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
 	}
@@ -149,7 +150,7 @@ func TestJobParams(t *testing.T) {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
 	}
 
-	out, err := ioutil.ReadFile(filepath.Join(target, "out.txt"))
+	out, err := ioutil.ReadFile(filepath.Join(cliDefaultArgs.target, "out.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -220,7 +221,7 @@ func TestSameGroupDifferentParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout1, cmderr1, err)
 	}
-	out1, err := ioutil.ReadFile(filepath.Join(target, "out.txt"))
+	out1, err := ioutil.ReadFile(filepath.Join(cliDefaultArgs.target, "out.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -229,7 +230,7 @@ func TestSameGroupDifferentParams(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout2, cmderr2, err)
 	}
-	out2, err := ioutil.ReadFile(filepath.Join(target, "out.txt"))
+	out2, err := ioutil.ReadFile(filepath.Join(cliDefaultArgs.target, "out.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +243,7 @@ func TestResultCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout1, cmderr1, err)
 	}
-	out1, err := ioutil.ReadFile(filepath.Join(target, "out.txt"))
+	out1, err := ioutil.ReadFile(filepath.Join(cliDefaultArgs.target, "out.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +256,7 @@ func TestResultCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout2, cmderr2, err)
 	}
-	out2, err := ioutil.ReadFile(filepath.Join(target, "out.txt"))
+	out2, err := ioutil.ReadFile(filepath.Join(cliDefaultArgs.target, "out.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -365,7 +366,7 @@ func TestBuildCoalescing(t *testing.T) {
 
 	wg.Wait()
 
-	out, err := ioutil.ReadFile(filepath.Join(target, "out.txt"))
+	out, err := ioutil.ReadFile(filepath.Join(cliDefaultArgs.target, "out.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/mistryd/mistryd_test.go
+++ b/cmd/mistryd/mistryd_test.go
@@ -246,11 +246,18 @@ func parseClientJSON(s string) (*types.BuildInfo, error) {
 // MISTRY_CLIENT_PATH environment variable or, if empty,  from the current
 // working directory where the tests are ran from.
 func cliBuildJob(args ...string) (string, string, error) {
+	return cliBuildJobTarget(target, args...)
+}
+
+func cliBuildJobTarget(trgt string, args ...string) (string, string, error) {
 	clientPath := os.Getenv("MISTRY_CLIENT_PATH")
 	if clientPath == "" {
-		clientPath = "./mistry"
+		clientPath = "/home/dtheodor/go/src/github.com/skroutz/mistry/mistry"
 	}
-	args = append([]string{clientPath, "build", "--host", host, "--port", port, "--target", target, "--transport-user", username}, args...)
+	if trgt == "" {
+		trgt = target
+	}
+	args = append([]string{clientPath, "build", "--host", host, "--port", port, "--target", trgt, "--transport-user", username}, args...)
 
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)


### PR DESCRIPTION
- [x] add --clear-target option, clears the --target directory
  * rsync: adds the `--delete` flag
  * scp: calls `os.Remove`s before running the `scp` command. `scp` has no flag that can do this
- [x] change Copy interface to do the copying and return `(string, error)` instead of returning the command string `[]string`. this is necessary to deal with clear-target errors, plus a design improvement as the Copy implementation should be an implementation detail (which could use an API instead of running commands on the OS), not the interface contract
- [x] improve test case setup code to allow to easily override the CLI default options (target directory in this case)

Closes #60