### PR TITLE
Output the jobs logs at the API and CLI output

### DIFF
--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -243,7 +243,9 @@ EXAMPLES:
 				}
 
 				if verbose {
-					fmt.Printf("Result after unmarshalling: %#v\n", bi)
+					fmt.Printf(
+						"\nResult:\nStarted at: %s ExitCode: %v Params: %s Cached: %v Coalesced: %v\n\nLogs:\n%s\n",
+						bi.StartedAt, bi.ExitCode, bi.Params, bi.Cached, bi.Coalesced, bi.Log)
 				}
 
 				if jsonResult {
@@ -254,10 +256,16 @@ EXAMPLES:
 					return fmt.Errorf("Build failed with exit code %d", bi.ExitCode)
 				}
 
+				if verbose {
+					fmt.Printf("Copying artifacts to %s", target)
+				}
 				out, err := ts.Copy(transportUser, host, project, bi.Path+"/*", target, clearTarget)
 				fmt.Println(out)
 				if err != nil {
 					return err
+				}
+				if verbose {
+					fmt.Printf("Artifacts copied to %s successfully\n", target)
 				}
 
 				return nil
@@ -289,7 +297,6 @@ func sendRequest(url string, reqBody []byte, verbose bool) ([]byte, error) {
 
 	if verbose {
 		fmt.Printf("Server response: %#v\n", resp)
-		fmt.Printf("Body: %s\n", respBody)
 	}
 
 	if resp.StatusCode != http.StatusCreated {

--- a/cmd/mistryd/public/templates/show.html
+++ b/cmd/mistryd/public/templates/show.html
@@ -36,28 +36,29 @@
             <div class="card-divider">
               <h4> Logs </h4>
             </div>
-            <p id="js-job-log">{{.Log}}</p>
+            <p id="js-job-log"></p>
           </div>
       </div>
     </div>
   </div>
 
   <script type="text/javascript">
+    const jobLog = document.getElementById('js-job-log')
+    const logs = {{.BuildInfo.Log}};
     const jobInfo = document.getElementById('js-job-info');
     const state = {{.State}}
-    const output = {{.Output}}
-    const jobJSON = JSON.parse(output);
 
     jobInfo.innerHTML += "Project: ".big() + {{.Project}} + "<br>";
     jobInfo.innerHTML += "State: ".big() + {{.State}} + "<br>";
-    jobInfo.innerHTML += "Started At: ".big() + new Date(jobJSON["StartedAt"]) + "<br>";
-    jobInfo.innerHTML += "Path: ".big() + jobJSON["Path"] + "<br>";
-    jobInfo.innerHTML += "Params: ".big() + JSON.stringify(jobJSON.Params) + "<br>";
-    jobInfo.innerHTML += "Cached: ".big() + jobJSON["Cached"] + "<br>";
-    jobInfo.innerHTML += "Coalesced: ".big() + jobJSON["Coalesced"] + "<br>";
-    jobInfo.innerHTML += "Error: ".big() + jobJSON["Err"] + "<br>";
-    jobInfo.innerHTML += "ExitCode: ".big() + jobJSON["ExitCode"] + "<br>";
-    jobInfo.innerHTML += "Transport method: ".big() + jobJSON["TransportMethod"] + "<br>";
+    jobInfo.innerHTML += "Started At: ".big() + new Date({{.BuildInfo.StartedAt}}) + "<br>";
+    jobInfo.innerHTML += "Path: ".big() + {{.BuildInfo.Path}} + "<br>";
+    jobInfo.innerHTML += "Params: ".big() + JSON.stringify({{.BuildInfo.Params}}) + "<br>";
+    jobInfo.innerHTML += "Cached: ".big() + {{.BuildInfo.Cached}} + "<br>";
+    jobInfo.innerHTML += "Coalesced: ".big() + {{.BuildInfo.Coalesced}} + "<br>";
+    jobInfo.innerHTML += "ExitCode: ".big() + {{.BuildInfo.ExitCode}} + "<br>";
+    jobInfo.innerHTML += "Transport method: ".big() + {{.BuildInfo.TransportMethod}} + "<br>";
+
+    jobLog.innerHTML += logs.split('\n').join('<br>')
 
     if (state == "pending") {
       setInterval(checkState, 3000);
@@ -76,7 +77,6 @@
       }
 
       const source = new EventSource('/log/{{.Project}}/{{.ID}}');
-      const jobLog = document.getElementById('js-job-log')
       source.onmessage = function(e) {
         jobLog.innerHTML += e.data + "</br>"
       };

--- a/cmd/mistryd/server_test.go
+++ b/cmd/mistryd/server_test.go
@@ -127,8 +127,8 @@ func TestHandleShowJob(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	jobID := (job[0].ID)
-	project := (job[0].Project)
+	jobID := job[0].ID
+	project := job[0].Project
 
 	// Request the show page of the job selected from the index page.
 	showPath := path.Join("/job", project, jobID)

--- a/pkg/types/build_info.go
+++ b/pkg/types/build_info.go
@@ -29,6 +29,8 @@ type BuildInfo struct {
 	TransportMethod TransportMethod
 
 	StartedAt time.Time
+
+	Log string
 }
 
 type ErrImageBuild struct {


### PR DESCRIPTION
Added the job logs as the `Log` attribute to the `BuildInfo`, so all API responses returning the BuildInfo  can provide job logs, in particular the `POST /jobs/` one. The CLI build invocation uses the response to output logs if the `--verbose` flag is set.

* Updated structs:
  * the Job already contained the BuildInfo (but serialized) as Job.Output. Removed that and added a proper struct Job.BuildInfo
  * move the Log to the BuildInfo, remove it from Job.Log
  * populate the BuildInfo with the log contents wherever is needed
  * update HTML template to use the updated structs
* move common code to read a job's BuildInfo JSON to a couple of new job functions. There was relevant code duplication when listing jobs, in the ExitCode function, and in tests
* update CLI to output the job logs

CLI output looks like this

![screenshot from 2018-04-30 18-20-33](https://user-images.githubusercontent.com/1549648/39435150-48d60bec-4ca3-11e8-95dc-495b13a8d328.png)

