### PR TITLE
return a 500 server error on template rendering failures

### DIFF
--- a/cmd/mistryd/server.go
+++ b/cmd/mistryd/server.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -328,10 +329,23 @@ func (s *Server) HandleShowJob(w http.ResponseWriter, r *http.Request) {
 	tmpl, err = tmpl.Parse(string(tmplBody))
 	if err != nil {
 		s.Log.Print(err)
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
-	tmpl.Execute(w, j)
+
+	buf := new(bytes.Buffer)
+	err = tmpl.Execute(buf, j)
+	if err != nil {
+		s.Log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	_, err = buf.WriteTo(w)
+	if err != nil {
+		s.Log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
 }
 
 // HandleServerPush emits build logs as Server-SentEvents (SSE).


### PR DESCRIPTION
Failing to generate HTML from a template resulted in a 200 status code with no error logs. Changed it so that we get a proper 500 and an error log.

This change requires an intermediate in memory buffer for the template render result, which on success is written to the response buffer. Previously, the half rendered template was sent directly to the response along with a 200 status code

Also change a wrong 400 to 500 on template parse failure