### PR TITLE
add --rebuild flag to client and server

### DIFF
--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -52,6 +52,7 @@ func main() {
 		jsonResult    bool
 		noWait        bool
 		clearTarget   bool
+		rebuild       bool
 	)
 
 	currentUser, err := user.Current()
@@ -120,6 +121,11 @@ EXAMPLES:
 					Name:        "json-result",
 					Usage:       "output the build result in JSON format to STDOUT (implies verbose: false)",
 					Destination: &jsonResult,
+				},
+				cli.BoolFlag{
+					Name:        "rebuild",
+					Usage:       "rebuild the docker image",
+					Destination: &rebuild,
 				},
 
 				// transport flags
@@ -213,7 +219,7 @@ EXAMPLES:
 					url += "?async"
 				}
 
-				jr := types.JobRequest{Project: project, Group: group, Params: params}
+				jr := types.JobRequest{Project: project, Group: group, Params: params, Rebuild: rebuild}
 				jrJSON, err := json.Marshal(jr)
 				if err != nil {
 					return err

--- a/cmd/mistryd/config.go
+++ b/cmd/mistryd/config.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/skroutz/mistry/pkg/filesystem"
+	"github.com/skroutz/mistry/pkg/utils"
 )
 
 // Config holds the configuration values that the Server needs in order to
@@ -42,6 +43,16 @@ func ParseConfig(addr string, fs filesystem.FileSystem, r io.Reader) (*Config, e
 
 	if cfg.UID == "" {
 		cfg.UID = strconv.Itoa(os.Getuid())
+	}
+
+	err = utils.PathIsDir(cfg.ProjectsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	err = utils.PathIsDir(cfg.BuildPath)
+	if err != nil {
+		return nil, err
 	}
 
 	return cfg, nil

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -27,14 +27,25 @@ func TestSimpleBuild(t *testing.T) {
 	}
 }
 
+func toCli(p types.Params) []string {
+	cliParams := make([]string, len(p))
+	i := 0
+	for k, v := range p {
+		cliParams[i] = fmt.Sprintf("--%s=%s", k, v)
+		i++
+	}
+	return cliParams
+}
+
 func TestSimpleRebuild(t *testing.T) {
 	// run a job, fetch its build time
-	cmdout, cmderr, err := cliBuildJob("--project", "simple", "--", "--test=rebuild")
+	params := types.Params{"test": "rebuild-cli"}
+	cmdout, cmderr, err := cliBuildJob("--project", "simple", "--", toCli(params)[0])
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
 	}
 
-	j, err := NewJob("simple", types.Params{"test": "rebuild"}, "", testcfg)
+	j, err := NewJob("simple", params, "", testcfg)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
@@ -55,7 +66,7 @@ func TestSimpleRebuild(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cmdout, cmderr, err = cliBuildJob("--project", "simple", "--rebuild", "--", "--test=rebuild")
+	cmdout, cmderr, err = cliBuildJob("--project", "simple", "--rebuild", "--", toCli(params)[0])
 	if err != nil {
 		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
 	}

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -132,10 +132,17 @@ func NewJob(project string, params types.Params, group string, cfg *Config) (*Jo
 
 // BuildImage builds the Docker image denoted by j.Image. If there is an
 // error, it will be of type types.ErrImageBuild.
-func (j *Job) BuildImage(ctx context.Context, uid string, c *docker.Client, out io.Writer) error {
+func (j *Job) BuildImage(ctx context.Context, uid string, c *docker.Client, out io.Writer, pullParent, noCache bool) error {
 	buildArgs := make(map[string]*string)
 	buildArgs["uid"] = &uid
-	buildOpts := dockertypes.ImageBuildOptions{Tags: []string{j.Image}, BuildArgs: buildArgs, NetworkMode: "host"}
+	buildOpts := dockertypes.ImageBuildOptions{
+		Tags:        []string{j.Image},
+		BuildArgs:   buildArgs,
+		NetworkMode: "host",
+		PullParent:  pullParent,
+		NoCache:     noCache,
+		ForceRemove: true,
+	}
 	resp, err := c.ImageBuild(context.Background(), bytes.NewBuffer(j.ImageTar), buildOpts)
 	if err != nil {
 		return types.ErrImageBuild{Image: j.Image, Err: err}

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -120,7 +120,7 @@ func NewJob(project string, params types.Params, group string, cfg *Config) (*Jo
 	j.BuildLogPath = BuildLogPath(j.PendingBuildPath)
 	j.BuildInfoFilePath = filepath.Join(j.PendingBuildPath, BuildInfoFname)
 
-	j.Image = ImgCntPrefix + j.ID
+	j.Image = ImgCntPrefix + j.Project
 	j.Container = ImgCntPrefix + j.ID
 
 	j.StartedAt = time.Now()

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -19,7 +19,7 @@ import (
 
 // Work performs the work denoted by j and returns a BuildInfo upon
 // successful completion, or an error.
-func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, err error) {
+func (s *Server) Work(ctx context.Context, j *Job, jr types.JobRequest) (buildInfo *types.BuildInfo, err error) {
 	log := log.New(os.Stderr, fmt.Sprintf("[worker] [%s] ", j), log.LstdFlags)
 	start := time.Now()
 	_, err = os.Stat(j.ReadyBuildPath)
@@ -176,7 +176,7 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 		return
 	}
 
-	err = j.BuildImage(ctx, s.cfg.UID, client, out)
+	err = j.BuildImage(ctx, s.cfg.UID, client, out, jr.Rebuild, jr.Rebuild)
 	if err != nil {
 		err = workErr("could not build docker image", err)
 		return

--- a/pkg/types/job_request.go
+++ b/pkg/types/job_request.go
@@ -1,7 +1,9 @@
 package types
 
+// JobRequest contains the data the job was requested with
 type JobRequest struct {
 	Project string
 	Params  Params
 	Group   string
+	Rebuild bool
 }


### PR DESCRIPTION
### Rebuilding a single image, from the client:

`mistry build --project foo --rebuild`

Add a new boolean `JobRequest.Rebuild`, which passes the options `--pull` and `--no-cache` to the image build.

Also add `--force-rm` by default true to image build, to avoid loose containers on build failures


### Rebuilding on the server

`mistryd --config <file> rebuild --project foo --project bar --fail-fast`

* can rebuild specific projects, or all of them if no projects are passed
* fail-fast whether to exit on first error, or keep running the rest of the images