### PR TITLE
Fix streaming

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -99,6 +99,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "819c1f0f3909913a9977d681d84689ceb7fbc90a0ebb579d3d7e159b6aa1b5d5"
+  inputs-digest = "ba64df132aad6d1df9e25d9a9376805ec86d69726d215b094d927c0ea0dfffcb"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
**Fix a bug with web view log streaming**
The bug was based in a racy condition that could be triggered when a
tailer had been terminated for a job ID just after a new job with the
same ID has started streaming.

To solve this we refactor the concurrency model of the tailers by
removing the sync map and depending only on new and closing clients
signals sent to the broker.

Fixes #71

Some other improvements:

- Fix a bug with clients number being negative
- broker: Close client channels when done