### PR TITLE
Build result missing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ### Added
 
+- server: Don't delete build results on docker image build failure [[#75](https://github.com/skroutz/mistry/issues/75)]
 - client: Add a `--timeout` option to specify maximum time to wait for a job [[#81](https://github.com/skroutz/mistry/pull/70)]
 - server: Introduced a configuration option to limit the number of concurrent builds [[73c44ec](https://github.com/skroutz/mistry/commit/73c44ecc924260ccf61bad220eb26cd51a1f30d6)]
 - server: Add `--rebuild` option to rebuild the docker images of a selection of projects ignoring the image cache [[#70](https://github.com/skroutz/mistry/pull/70)]

--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -265,8 +265,8 @@ EXAMPLES:
 				}
 
 				// Transfer the result
-				bi := types.BuildInfo{}
-				err = json.Unmarshal([]byte(body), &bi)
+				bi := types.NewBuildInfo()
+				err = json.Unmarshal([]byte(body), bi)
 				if err != nil {
 					return err
 				}

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -283,7 +283,7 @@ func TestImageBuildFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	assertEq(bi.ExitCode, -999, t)
+	assertEq(bi.ExitCode, types.ContainerFailureExitCode, t)
 }
 
 func TestLogs(t *testing.T) {

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -258,6 +258,32 @@ func TestImageBuildFailure(t *testing.T) {
 	if !strings.Contains(cmderr, expErr) {
 		t.Fatalf("Expected '%s' to contain '%s'", cmderr, expErr)
 	}
+	j, err := NewJob("image-build-failure", types.Params{}, "", testcfg)
+	if err != nil {
+		t.Fatalf("failed to create job; %s", err)
+	}
+
+	errDockercmd := "apt-get install -y fofkoeakodksao"
+	log, err := ReadJobLogs(j.ReadyBuildPath)
+	if err != nil {
+		t.Fatalf("failed to read job log; %s", err)
+	}
+
+	if !strings.Contains(string(log), errDockercmd) {
+		t.Fatalf("Expected out log '%s' to contain '%s'", string(log), cmderr)
+	}
+
+	buildInfoPath := filepath.Join(j.ReadyBuildPath, BuildInfoFname)
+	bi := types.NewBuildInfo()
+	biBlob, err := ioutil.ReadFile(buildInfoPath)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	err = json.Unmarshal(biBlob, bi)
+	if err != nil {
+		t.Fatalf("%s", err)
+	}
+	assertEq(bi.ExitCode, -999, t)
 }
 
 func TestLogs(t *testing.T) {

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -122,12 +122,12 @@ func TestAsyncSimpleBuild(t *testing.T) {
 		t.Fatalf("failed to find job build info at %s: %s", buildInfoPath, err)
 	}
 
-	bi := types.BuildInfo{}
+	bi := types.NewBuildInfo()
 	biBlob, err := ioutil.ReadFile(buildInfoPath)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}
-	err = json.Unmarshal(biBlob, &bi)
+	err = json.Unmarshal(biBlob, bi)
 	if err != nil {
 		t.Fatalf("%s", err)
 	}

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -416,7 +416,7 @@ func ReadJobLogs(jobPath string) ([]byte, error) {
 // ReadJobBuildInfo returns the BuildInfo found at jobPath
 func ReadJobBuildInfo(path string, logs bool) (*types.BuildInfo, error) {
 	buildInfoPath := filepath.Join(path, BuildInfoFname)
-	buildInfo := &types.BuildInfo{}
+	buildInfo := types.NewBuildInfo()
 
 	buildInfoBytes, err := ioutil.ReadFile(buildInfoPath)
 	if err != nil {

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -101,7 +101,7 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 
 	defer func() {
 		if cleanupPending {
-			derr := s.cfg.FileSystem.Remove(j.PendingBuildPath)
+			derr := os.Rename(j.PendingBuildPath, j.ReadyBuildPath)
 			if derr != nil {
 				errstr := "could not clean hanging pending path"
 				if err == nil {

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -143,28 +143,12 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 		}
 	}()
 
-	infoFile, err := os.Create(j.BuildInfoFilePath)
-	if err != nil {
-		err = workErr("could not create build info file", err)
-		return
-	}
-	defer func() {
-		ferr := infoFile.Close()
-		errstr := "could not close build info file"
-		if ferr != nil {
-			if err == nil {
-				err = fmt.Errorf("%s; %s", errstr, ferr)
-			} else {
-				err = fmt.Errorf("%s; %s | %s", errstr, ferr, err)
-			}
-		}
-	}()
 	biJSON, err := json.Marshal(buildInfo)
 	if err != nil {
 		err = workErr("could not serialize build info", err)
 		return
 	}
-	_, err = infoFile.Write(biJSON)
+	err = ioutil.WriteFile(j.BuildInfoFilePath, biJSON, 0666)
 	if err != nil {
 		err = workErr("could not write build info to file", err)
 		return
@@ -188,17 +172,12 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 		return
 	}
 
-	_, err = infoFile.Seek(0, 0)
-	if err != nil {
-		err = workErr("could not set the offset for the build_info file", err)
-		return
-	}
 	biJSON, err = json.Marshal(buildInfo)
 	if err != nil {
 		err = workErr("could not serialize build info", err)
 		return
 	}
-	_, err = infoFile.Write(biJSON)
+	err = ioutil.WriteFile(j.BuildInfoFilePath, biJSON, 0666)
 	if err != nil {
 		err = workErr("could not write build info to file", err)
 		return

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -42,12 +42,11 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 		return
 	}
 
-	buildInfo = &types.BuildInfo{
-		Path:            filepath.Join(j.ReadyBuildPath, DataDir, ArtifactsDir),
-		TransportMethod: types.Rsync,
-		Params:          j.Params,
-		StartedAt:       j.StartedAt,
-	}
+	buildInfo = types.NewBuildInfo()
+	buildInfo.Path = filepath.Join(j.ReadyBuildPath, DataDir, ArtifactsDir)
+	buildInfo.TransportMethod = types.Rsync
+	buildInfo.Params = j.Params
+	buildInfo.StartedAt = j.StartedAt
 
 	added := s.jq.Add(j)
 	if added {

--- a/pkg/types/build_info.go
+++ b/pkg/types/build_info.go
@@ -5,7 +5,9 @@ import (
 	"time"
 )
 
-const containerFailureExitCode = -999
+// ContainerFailureExitCode is the exit code that signifies a failure
+// before even running the container
+const ContainerFailureExitCode = -999
 
 type BuildInfo struct {
 	// Job parameters
@@ -43,7 +45,7 @@ type ErrImageBuild struct {
 func NewBuildInfo() *BuildInfo {
 	bi := new(BuildInfo)
 	bi.StartedAt = time.Now()
-	bi.ExitCode = containerFailureExitCode
+	bi.ExitCode = ContainerFailureExitCode
 
 	return bi
 }

--- a/pkg/types/build_info.go
+++ b/pkg/types/build_info.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+const containerFailureExitCode = -999
+
 type BuildInfo struct {
 	// Job parameters
 	Params Params
@@ -36,6 +38,14 @@ type BuildInfo struct {
 type ErrImageBuild struct {
 	Image string
 	Err   error
+}
+
+func NewBuildInfo() *BuildInfo {
+	bi := new(BuildInfo)
+	bi.StartedAt = time.Now()
+	bi.ExitCode = containerFailureExitCode
+
+	return bi
 }
 
 func (e ErrImageBuild) Error() string {


### PR DESCRIPTION
- [x] Introduce constructor for the BuildInfo
This constructor allows us to set the default ExitCode to 1 (overriding
the go's default 0).
- [x] Properly persist job results in case of failure
With this change, we copy the pending jobs directories to the ready path
whether they have failed or not. This makes sure we keep some
information (build_info.json and out.log files) about the failed jobs.
- [x] Refactor pending hanging jobs removal 
With this change we will handle hanging pending jobs by depending on
setted errors. This enables us to simplify the cleanup flow and drop the
`shouldCleanup` flag. As a side effect in order to be compatible with the current behavior we
take extra care of the LatestBuildPath which should point to the last
successful build.
- [x] Fix bug with overwriting build_info file
The new JSON that is going to overwrite the existing file may be
shorter in length. Thus, leaving some characters behind from the
previous write and making the JSON invalid.
We also remove the file descriptor since it not needed anywhere.

Fixes #75.