### PR TITLE
mistryd rebuild cli improvements

### DIFF
--- a/cmd/mistryd/main.go
+++ b/cmd/mistryd/main.go
@@ -105,7 +105,8 @@ func main() {
 					Usage: "the project to build. Multiple projects can be specified. If not passed, all projects are built",
 				},
 				cli.BoolFlag{
-					Name: "verbose, v",
+					Name:  "verbose, v",
+					Usage: "print logs from docker build and run",
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -117,7 +118,7 @@ func main() {
 				logger := log.New(os.Stdout, "", 0)
 				r, err := RebuildImages(cfg, logger, c.StringSlice("project"), c.Bool("fail-fast"), c.Bool("verbose"))
 				if err != nil {
-					return fmt.Errorf("Image error, existing early, partial result: %s", r)
+					return err
 				}
 				if len(r.failed) > 0 {
 					return fmt.Errorf("%s", r)

--- a/cmd/mistryd/mistryd_test.go
+++ b/cmd/mistryd/mistryd_test.go
@@ -181,12 +181,10 @@ func TestRebuildImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	b := new(strings.Builder)
-	r, err := RebuildImages(testcfg, logger, b, []string{"simple"}, true)
-	t.Log(b.String())
+	r, err := RebuildImages(testcfg, logger, []string{"simple"}, true, true)
 	failIfError(err, t)
 	assertEq(r.successful, 1, t)
-	assertEq(r.failed, 0, t)
+	assertEq(len(r.failed), 0, t)
 
 	// fetch last build time, make sure it is different
 	i2, _, err := client.ImageInspectWithRaw(context.Background(), j.Image)
@@ -197,10 +195,9 @@ func TestRebuildImages(t *testing.T) {
 }
 
 func TestRebuildImagesNonExistingProject(t *testing.T) {
-	buf := new(bytes.Buffer)
-	r, err := RebuildImages(testcfg, logger, buf, []string{"shouldnotexist"}, true)
+	r, err := RebuildImages(testcfg, logger, []string{"shouldnotexist"}, true, true)
 	assertEq(r.successful, 0, t)
-	assertEq(r.failed, 1, t)
+	assertEq(r.failed, []string{"shouldnotexist"}, t)
 	if err == nil {
 		t.Fatal("Expected unknown project error")
 	}


### PR DESCRIPTION
* add `rebuild --verbose`, omit build logs when not true
* a bit more useful logs, with build times per project
* on failures, return non 0 exit code
* print the list of failed projects in the final output to avoid having to manually search the logs