### PR TITLE
add build --timeout

### DIFF
--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -134,6 +134,7 @@ EXAMPLES:
 					Name:        "timeout",
 					Usage:       "time to wait for the build to finish, accepts values as defined at https://golang.org/pkg/time/#ParseDuration",
 					Destination: &timeout,
+					Value:       "60m",
 				},
 
 				// transport flags

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -90,6 +90,15 @@ func TestNonGroupSubsequentInvocation(t *testing.T) {
 	}
 }
 
+func TestBuildTimeout(t *testing.T) {
+	timeout := "1s"
+	_, stderr, err := cliBuildJob("--project", "sleep", "--timeout", timeout, "--", "--test=client-timeout")
+	if err == nil {
+		t.Fatalf("Expected timeout error")
+	}
+	assertEq(strings.Contains(stderr, "The build did not finish after "+timeout), true, t)
+}
+
 func TestAsyncSimpleBuild(t *testing.T) {
 	cmdout, cmderr, err := cliBuildJob("--json-result", "--project", "simple", "--no-wait", "--", "--test=async")
 	if err != nil {


### PR DESCRIPTION
Add a `mistry build --timeout 15s`. The client will exit with an error if the buidl takes longer than the timeout. The timeout string notation is defined at https://golang.org/pkg/time/#ParseDuration

connection timeouts (e.g. socket read() timeout and others) are already taken care of well enough by the `DefaultTransport` that is used in the http.Client by default

https://github.com/golang/go/blob/47be3d49c7d7ff77e675b0d0fb78c05fdb43dee2/src/net/http/transport.go#L39-L50

Relevant material https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/#clienttimeouts

Closes #67