### PR TITLE
job: Make the stringer interface less verbose

### DIFF
--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -235,8 +235,8 @@ func (j *Job) StartContainer(ctx context.Context, cfg *Config, c *docker.Client,
 
 func (j *Job) String() string {
 	return fmt.Sprintf(
-		"{project=%s params=%s group=%s id=%s}",
-		j.Project, j.Params, j.Group, j.ID[:7])
+		"{project=%s group=%s id=%s}",
+		j.Project, j.Group, j.ID[:7])
 }
 
 // MarshalJSON serializes the Job to JSON


### PR DESCRIPTION
As it stands the worker logger prints all the job information in every
logging action. If the job's params are big e.g. a Gemfile or a
yarn.lock was passed, the server logs become unreadable.

Instead, we can return the job ID, group and the project which are
enough for the job identification.