### PR TITLE
output container stderr to the client build output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ### Added
 
-- server: Don't delete build results on docker image build failure [[#75](https://github.com/skroutz/mistry/issues/75)]
+- client: Output container stderr on non-zero exit code [[#85](https://github.com/skroutz/mistry/pull/85)]
 - client: Add a `--timeout` option to specify maximum time to wait for a job [[#81](https://github.com/skroutz/mistry/pull/70)]
 - server: Introduced a configuration option to limit the number of concurrent builds [[73c44ec](https://github.com/skroutz/mistry/commit/73c44ecc924260ccf61bad220eb26cd51a1f30d6)]
 - server: Add `--rebuild` option to rebuild the docker images of a selection of projects ignoring the image cache [[#70](https://github.com/skroutz/mistry/pull/70)]
@@ -27,6 +27,7 @@ Breaking changes are prefixed with a "[BREAKING]" label.
 
 ### Fixed
 
+- Don't delete build results on docker image build failure [[#75](https://github.com/skroutz/mistry/issues/75)]
 - If a container with the same name exists, we remove it so that the new container
   can run [[#20](https://github.com/skroutz/mistry/issues/20)]
 - Streaming log output in web view might occassionally hang [[7c07ca1](7c07ca177639cd6be7f9a860fb39c01370f35779)]

--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -234,7 +234,8 @@ EXAMPLES:
 					}
 				}
 
-				url := fmt.Sprintf("http://%s:%s/%s", host, port, JobsPath)
+				baseURL := fmt.Sprintf("http://%s:%s", host, port)
+				url := baseURL + "/" + JobsPath
 				if noWait {
 					url += "?async"
 				}
@@ -271,6 +272,10 @@ EXAMPLES:
 					return err
 				}
 
+				if !jsonResult {
+					fmt.Println("Logs can be found at", baseURL+"/"+bi.URL)
+				}
+
 				if verbose {
 					fmt.Printf(
 						"\nResult:\nStarted at: %s ExitCode: %v Params: %s Cached: %v Coalesced: %v\n\nLogs:\n%s\n",
@@ -284,12 +289,14 @@ EXAMPLES:
 				if bi.ExitCode != 0 {
 					if bi.ErrLog != "" {
 						fmt.Fprintln(os.Stderr, "Container error logs:\n", bi.ErrLog)
+					} else {
+						fmt.Fprintln(os.Stderr, "There are no container error logs.")
 					}
 					return fmt.Errorf("Build failed with exit code %d", bi.ExitCode)
 				}
 
 				if verbose {
-					fmt.Println("Copying artifacts to", target)
+					fmt.Println("Copying artifacts to", target, "...")
 				}
 				out, err := ts.Copy(transportUser, host, project, bi.Path+"/*", target, clearTarget)
 				fmt.Println(out)
@@ -297,7 +304,7 @@ EXAMPLES:
 					return err
 				}
 				if verbose {
-					fmt.Println("Artifacts copied to", target, "successfully")
+					fmt.Println("Artifacts copied to", target)
 				}
 
 				return nil

--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -60,7 +59,8 @@ func main() {
 
 	currentUser, err := user.Current()
 	if err != nil {
-		log.Fatal("Cannot fetch current user; ", err)
+		fmt.Fprintln(os.Stderr, "Cannot fetch current user:", err)
+		os.Exit(1)
 	}
 
 	cli.AppHelpTemplate = fmt.Sprintf(`%s
@@ -259,7 +259,7 @@ EXAMPLES:
 
 				if noWait {
 					if verbose {
-						fmt.Printf("Build scheduled successfully\n")
+						fmt.Println("Build scheduled successfully")
 					}
 					return nil
 				}
@@ -278,15 +278,18 @@ EXAMPLES:
 				}
 
 				if jsonResult {
-					fmt.Printf("%s", body)
+					fmt.Printf("%s\n", body)
 				}
 
 				if bi.ExitCode != 0 {
+					if bi.ErrLog != "" {
+						fmt.Fprintln(os.Stderr, "Container error logs:\n", bi.ErrLog)
+					}
 					return fmt.Errorf("Build failed with exit code %d", bi.ExitCode)
 				}
 
 				if verbose {
-					fmt.Printf("Copying artifacts to %s", target)
+					fmt.Println("Copying artifacts to", target)
 				}
 				out, err := ts.Copy(transportUser, host, project, bi.Path+"/*", target, clearTarget)
 				fmt.Println(out)
@@ -294,7 +297,7 @@ EXAMPLES:
 					return err
 				}
 				if verbose {
-					fmt.Printf("Artifacts copied to %s successfully\n", target)
+					fmt.Println("Artifacts copied to", target, "successfully")
 				}
 
 				return nil
@@ -304,7 +307,8 @@ EXAMPLES:
 
 	err = app.Run(os.Args)
 	if err != nil {
-		log.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }
 

--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -28,6 +28,20 @@ func TestSimpleBuild(t *testing.T) {
 	}
 }
 
+func TestContainerErrorLogs(t *testing.T) {
+	_, cmderr, err := cliBuildJob("--project", "bad_entrypoint", "--", "--test=error-logs")
+	if err == nil {
+		t.Fatal("Expected mistry-cli error")
+	}
+	expecteds := [2]string{"this is stderr", "missing_command: command not found"}
+
+	for _, expected := range expecteds {
+		if !strings.Contains(cmderr, expected) {
+			t.Fatalf("Expected stderr to contain '%s'", expected)
+		}
+	}
+}
+
 func toCli(p types.Params) []string {
 	cliParams := make([]string, len(p))
 	i := 0

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -177,7 +177,7 @@ func (j *Job) BuildImage(ctx context.Context, uid string, c *docker.Client, out 
 //
 // NOTE: If there was an error with the user's dockerfile, the returned exit
 // code will be 1 and the error nil.
-func (j *Job) StartContainer(ctx context.Context, cfg *Config, c *docker.Client, out io.Writer) (int, error) {
+func (j *Job) StartContainer(ctx context.Context, cfg *Config, c *docker.Client, out, outErr io.Writer) (int, error) {
 	config := container.Config{User: cfg.UID, Image: j.Image}
 
 	mnts := []mount.Mount{{Type: mount.TypeBind, Source: filepath.Join(j.PendingBuildPath, DataDir), Target: DataDir}}
@@ -213,7 +213,7 @@ func (j *Job) StartContainer(ctx context.Context, cfg *Config, c *docker.Client,
 	}
 	defer logs.Close()
 
-	_, err = stdcopy.StdCopy(out, out, logs)
+	_, err = stdcopy.StdCopy(out, io.MultiWriter(out, outErr), logs)
 	if err != nil {
 		return 0, err
 	}

--- a/cmd/mistryd/server.go
+++ b/cmd/mistryd/server.go
@@ -281,6 +281,10 @@ func (s *Server) HandleShowJob(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+func getJobURL(j *Job) string {
+	return strings.Join([]string{"job", j.Project, j.ID}, "/")
+}
+
 // HandleServerPush emits build logs as Server-SentEvents (SSE).
 func (s *Server) HandleServerPush(w http.ResponseWriter, r *http.Request) {
 	if r.Method != "GET" {

--- a/cmd/mistryd/testdata/projects/bad_entrypoint/Dockerfile
+++ b/cmd/mistryd/testdata/projects/bad_entrypoint/Dockerfile
@@ -1,0 +1,8 @@
+FROM debian:stretch
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/cmd/mistryd/testdata/projects/bad_entrypoint/docker-entrypoint.sh
+++ b/cmd/mistryd/testdata/projects/bad_entrypoint/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+>&2 echo "this is stderr"
+echo "this is stdout"
+missing_command
+
+exit 0

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "github.com/docker/distribution"
@@ -187,7 +188,9 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 		return
 	}
 
-	buildInfo.ExitCode, err = j.StartContainer(ctx, s.cfg, client, out)
+	var outErr strings.Builder
+	buildInfo.ExitCode, err = j.StartContainer(ctx, s.cfg, client, out, &outErr)
+
 	if err != nil {
 		err = workErr("could not start docker container", err)
 		return
@@ -218,6 +221,7 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 	}
 
 	buildInfo.Log = string(finalLog)
+	buildInfo.ErrLog = outErr.String()
 
 	log.Println("Finished after", time.Now().Sub(start).Truncate(time.Millisecond))
 	return

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -48,6 +48,7 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 	buildInfo.TransportMethod = types.Rsync
 	buildInfo.Params = j.Params
 	buildInfo.StartedAt = j.StartedAt
+	buildInfo.URL = getJobURL(j)
 
 	added := s.jq.Add(j)
 	if added {

--- a/pkg/types/build_info.go
+++ b/pkg/types/build_info.go
@@ -34,7 +34,10 @@ type BuildInfo struct {
 
 	StartedAt time.Time
 
+	// Contains the stdout and stderr as output by the container
 	Log string
+	// Contains the stderr output by the container
+	ErrLog string
 }
 
 type ErrImageBuild struct {

--- a/pkg/types/build_info.go
+++ b/pkg/types/build_info.go
@@ -36,8 +36,12 @@ type BuildInfo struct {
 
 	// Contains the stdout and stderr as output by the container
 	Log string
+
 	// Contains the stderr output by the container
 	ErrLog string
+
+	// The relative URL (excluding hostname) at which the job logs are available
+	URL string
 }
 
 type ErrImageBuild struct {


### PR DESCRIPTION
* `mistry build` will output the container stderr if the container exit code is non zero
* `mistry build` will always output the URL at which the job logs are available
* The container stderr is seperately stored as `BuildInfo.ErrLog` (the `BuildInfo.Log` still contains all the logs) and returned with the POST new job response
* the client now logs its errors to stderr
* use Println in various client logs instead of Printf

Output of a job that fails:
![screenshot from 2018-05-15 10-53-34](https://user-images.githubusercontent.com/1549648/40043868-6e8a7e40-582e-11e8-95dc-9f0a8c25dae5.png)
