### PR TITLE
Readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ $ go get -u github.com/skroutz/mistry/cmd/mistry
 
 
 
+Examples
+--------------------------------------------------
+For example projects take a look at the [examples](https://github.com/skroutz/mistry/_examples) directory.
+
+
+
+
+
+
 Usage
 --------------------------------------------------
 To boot the server, a configuration file is needed:

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+Here is a little preview of how building looks with mistry.
+
+To start building follow the [setup instructions](https://github.com/skroutz/mistry/wiki/Setup).

--- a/_examples/bundler-cache/Dockerfile
+++ b/_examples/bundler-cache/Dockerfile
@@ -1,0 +1,17 @@
+FROM debian:stretch
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    libcurl4-openssl-dev \
+    libsystemd-dev \
+    pkg-config \
+    ruby ruby-dev ruby-bundler \
+    zlib1g-dev
+
+WORKDIR /data
+
+COPY docker-entrypoint /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint"]

--- a/_examples/bundler-cache/README.md
+++ b/_examples/bundler-cache/README.md
@@ -1,0 +1,49 @@
+# Bundler
+
+The project contains a Dockerfile and a docker-entrypoint that describe
+it. We recommend reading the [source](_examples/bundler-cache) of these files as a form of
+documentation for developing other projects.
+
+
+1. Create the target directory for the artifacts
+
+```sh
+$ mdkir /tmp/gems
+```
+
+2. Schedule a job
+
+```sh
+$ ./mistry build --host localhost               \
+--project bundler                               \
+--group my-group                                \
+--target /tmp/gems                              \
+--transport rsync                               \
+--clear-target                                  \
+--verbose                                       \
+--                                              \
+--Gemfile=@/tmp/mistry/projects/bundler/Gemfile \
+--Gemfile.lock=@/tmp/mistry/projects/bundler/Gemfile.lock
+```
+
+3. (optional) Observe the building process from the webview
+
+Visit http://localhost:8462/job/bundler/:job_id
+
+
+4. When the job has finished building the artifacts will by copied to
+the target directory(`/tmp/gems` in our case)
+
+```sh
+$ tree -L 3 /tmp/gems
+
+/tmp/gems
+└── ruby
+    └── 2.3.0
+        ├── build_info
+        ├── cache
+        ├── doc
+        ├── extensions
+        ├── gems
+        └── specifications
+```

--- a/_examples/bundler-cache/docker-entrypoint
+++ b/_examples/bundler-cache/docker-entrypoint
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+require 'open3'
+
+# non-buffered stdout
+STDOUT.sync = true
+
+GEMFILE = File.read("params/Gemfile").strip
+abort "Gemfile param cannot be empty" if GEMFILE.empty?
+
+GEMFILE_LOCK = File.read("params/Gemfile.lock").strip
+abort "Gemfile.lock param cannot be empty" if GEMFILE_LOCK.empty?
+
+cmd = "bundle install --path /data/artifacts --no-prune --deployment --jobs=4 --gemfile=params/Gemfile"
+puts "Running '#{cmd}'..."
+Open3.popen2(cmd) do |_, stdout, status_thread|
+  stdout.each_line { |line| puts line }
+  unless status_thread.value.success?
+    abort "Aborting #{cmd} returned non-zero exit code (#{status_thread.value})"
+  end
+end

--- a/_examples/bundler-cache/gemfile/Gemfile
+++ b/_examples/bundler-cache/gemfile/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'activesupport', '5.2.0'

--- a/_examples/bundler-cache/gemfile/Gemfile.lock
+++ b/_examples/bundler-cache/gemfile/Gemfile.lock
@@ -1,0 +1,24 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    concurrent-ruby (1.0.5)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (= 5.2.0)
+
+BUNDLED WITH
+   1.16.1


### PR DESCRIPTION
- Introduce `_examples` directory
This directory can be used to hold the source code for usage examples.
For starters, it will contain a bundler project which builds Ruby gems.

- README: Add complete, runnable examples

Closes #33