### PR TITLE
Add support for opaque build params

### DIFF
--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -74,11 +74,12 @@ JOB PARAMETERS:
 EXAMPLES:
 	1. Schedule a job with a group and some parameters and put artifacts under
 		/tmp/yarn using rsync. Prefixing a file name with @ will cause the contents
-		of yarn.lock to be sent as parameters.
+		of yarn.lock to be sent as parameters. Parameters prepended with '_' are opaque
+		and do not affect the build result.
 
 		$ {{.HelpName}} --host example.org --port 9090 --project yarn \
 			--group group_name --transport rsync --target /tmp/yarn \
-			-- --lockfile=@yarn.lock --foo=bar
+			-- --lockfile=@yarn.lock --foo=bar --_ignored=true
 
 	2. Schedule a build and exit early without waiting for the result by setting
 		the no-wait flag.

--- a/cmd/mistryd/job.go
+++ b/cmd/mistryd/job.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	dockertypes "github.com/docker/docker/api/types"
@@ -111,6 +112,12 @@ func NewJob(project string, params types.Params, group string, cfg *Config) (*Jo
 	// compute ID
 	keys := []string{}
 	for k := range params {
+		// params opaque to the build are not taken into account
+		// when calculating a job's ID
+		if strings.HasPrefix(k, "_") {
+			continue
+		}
+
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)

--- a/cmd/mistryd/job_test.go
+++ b/cmd/mistryd/job_test.go
@@ -65,4 +65,15 @@ func TestJobID(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	opqParams := params
+	opqParams["_production"] = "ignored"
+
+	// check that params prepended with _ are ignored for ID creation
+	j7, err := NewJob(project, opqParams, group, testcfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEq(j6.ID, j7.ID, t)
+
 }


### PR DESCRIPTION
Any dynamic build params prepended with a `_` are not taken into account when calculating the job's ID.