### PR TITLE
client: Fix param parsing when spaces are used

### DIFF
--- a/cmd/mistry/main.go
+++ b/cmd/mistry/main.go
@@ -208,17 +208,7 @@ EXAMPLES:
 					return fmt.Errorf("invalid transport argument (%v)", transport)
 				}
 
-				// Normalize dynamic arguments by trimming the `--` and
-				// creating the params map with the result.
-				var dynamicArgs []string
-				for _, v := range c.Args() {
-					dynamicArgs = append(dynamicArgs, strings.TrimLeft(v, "--"))
-				}
-				params := make(map[string]string)
-				for _, v := range dynamicArgs {
-					arg := strings.Split(v, "=")
-					params[arg[0]] = arg[1]
-				}
+				params := parseDynamicArgs(c.Args())
 
 				// Dynamic arguments starting with `@` are considered actual
 				// files in the filesystem.
@@ -344,4 +334,26 @@ func sendRequest(url string, reqBody []byte, verbose bool, timeout time.Duration
 func isTimeout(err error) bool {
 	urlErr, ok := err.(*url.Error)
 	return ok && urlErr.Timeout()
+}
+
+func parseDynamicArgs(args cli.Args) map[string]string {
+	parsed := make(map[string]string)
+
+	for i := 0; i < len(args); {
+		arg := strings.TrimLeft(args[i], "--")
+
+		if strings.Contains(arg, "=") {
+			parts := strings.Split(arg, "=")
+			parsed[parts[0]] = parts[1]
+			i++
+		} else if i+1 < len(args) {
+			parsed[arg] = args[i+1]
+			i = i + 2
+		} else {
+			i++
+
+		}
+	}
+
+	return parsed
 }

--- a/cmd/mistry/main_test.go
+++ b/cmd/mistry/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestParseDynamicArgs(t *testing.T) {
+	cases := []struct {
+		In       cli.Args
+		Expected map[string]string
+	}{
+		{cli.Args{"--a", "b", "c=d", "e=f", "--g", "h"},
+			map[string]string{"a": "b", "c": "d", "e": "f", "g": "h"}},
+
+		{cli.Args{"a=b", "--@c", "d", "e=f", "--g", "h"},
+			map[string]string{"a": "b", "@c": "d", "e": "f", "g": "h"}},
+
+		{cli.Args{"a=b", "--c", "d"},
+			map[string]string{"a": "b", "c": "d"}},
+
+		{cli.Args{"--a", "b", "@c=d"},
+			map[string]string{"a": "b", "@c": "d"}},
+
+		{cli.Args{"a=b", "c=d"},
+			map[string]string{"a": "b", "c": "d"}},
+
+		{cli.Args{"a", "b", "--c", "d"},
+			map[string]string{"a": "b", "c": "d"}},
+
+		{cli.Args{"--a", "b"}, map[string]string{"a": "b"}},
+		{cli.Args{"a=b"}, map[string]string{"a": "b"}},
+	}
+
+	for _, c := range cases {
+		actual := parseDynamicArgs(c.In)
+
+		if !reflect.DeepEqual(actual, c.Expected) {
+			t.Errorf("expected %v, got %v", c.Expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
Up until now we only recognized dynamic parameters passed in the
following format:

    $ mistry -- --foo=bar --a=b --b=c

With this patch, the above can also be written as:
the above:

    $ mistry -- --foo bar --a b --b c

Fixes #23