### PR TITLE
Pass relative paths to Docker build context

### DIFF
--- a/cmd/mistryd/end_to_end_test.go
+++ b/cmd/mistryd/end_to_end_test.go
@@ -367,6 +367,19 @@ func TestExitCode(t *testing.T) {
 	assert(br.ExitCode, 77, t)
 }
 
+func TestCopyDir(t *testing.T) {
+	cmdout, cmderr, err := cliBuildJob("--json-result", "--project", "copy-folder")
+	if err != nil {
+		t.Fatalf("mistry-cli stdout: %s, stderr: %s, err: %#v", cmdout, cmderr, err)
+	}
+	br, err := parseClientJSON(cmdout)
+	if err != nil {
+		panic(err)
+	}
+
+	assert(br.ExitCode, 0, t)
+}
+
 func TestSameGroupDifferentParams(t *testing.T) {
 	cmdout1, cmderr1, err := cliBuildJob("--project", "result-cache", "--group", "foo", "--", "--foo=bar")
 	if err != nil {

--- a/cmd/mistryd/testdata/projects/copy-folder/Dockerfile
+++ b/cmd/mistryd/testdata/projects/copy-folder/Dockerfile
@@ -1,0 +1,9 @@
+FROM debian:stretch
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+COPY koko/ /koko/
+WORKDIR /data
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/cmd/mistryd/testdata/projects/copy-folder/docker-entrypoint.sh
+++ b/cmd/mistryd/testdata/projects/copy-folder/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#HACK: mistry will attempt to copy all artifacts out of the container
+# Therefore we need to leave something behind. This might or might not be
+# the intented behaviour. Revisit in the future.
+touch /data/artifacts/foo
+stat /koko/lala.txt

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -74,6 +74,12 @@ func Tar(root string) ([]byte, error) {
 			return err
 		}
 
+		// Preserve directory structure when docker "untars" the build context
+		hdr.Name, err = filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+
 		err = tw.WriteHeader(hdr)
 		if err != nil {
 			return err


### PR DESCRIPTION
Docker accepts a so called "context" that contains all files that a
build can refer to. For instance, when `docker build -t example .` is
ran, all files under the current directory, are being tar-ed and copied
to a temporary location as the build's context.

In our case, in order to build a mistry project, docker's golang package
is being used. Docker client's [`ImageBuild`](https://godoc.org/docker.io/go-docker#Client.ImageBuild), takes an io.Reader
containing that build context. Again, a tarball with all the necessary
files.

The tarball we were creating was adding only the file's name as the
desired "untar" path to the tarball header, therefore,
all files were being untar-ed under the root folder.

The issue described above, led to `COPY` instructions failing, when
folders were being copied (or files under a certain directory for that matter).[Issue-124](https://github.com/skroutz/mistry/issues/124)
