### PR TITLE
Prometheus integration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -37,6 +37,14 @@
   version = "v1.0.5"
 
 [[projects]]
+  digest = "1:ac2a05be7167c495fe8aaf8aaf62ecf81e78d2180ecb04e16778dc6c185c96a5"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = ""
+  revision = "37c8de3658fcb183f997c4e13e8337516ab753e6"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:8ab4bd543457728b06fb2e0b96c02dd593261cb27a3455ca433e89bc68c601f1"
   name = "github.com/docker/distribution"
   packages = [
@@ -110,6 +118,28 @@
   revision = "aabc10ec26b754e797f9028f4589c5b7bd90dc20"
 
 [[projects]]
+  digest = "1:6532affeeaaccdc6919d5773516176b77de02b4af8cf9a7fac16bae77aa319c5"
+  name = "github.com/golang/protobuf"
+  packages = [
+    "proto",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/timestamp",
+  ]
+  pruneopts = ""
+  revision = "4846b58453b3708320bdb524f25cc5a1d9cda4d4"
+  version = "v1.4.3"
+
+[[projects]]
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = ""
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   digest = "1:5d9b668b0b4581a978f07e7d2e3314af18eb27b3fb5d19b70185b7c575723d11"
   name = "github.com/opencontainers/go-digest"
   packages = ["."]
@@ -124,6 +154,51 @@
   pruneopts = ""
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  digest = "1:6bea0cda3fc62855d5312163e7d259fb97e31692d93c08cfffbeb2d00df0f13c"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/internal",
+    "prometheus/promauto",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
+  revision = "170205fb58decfd011f1550d4cfb737230d7ae4f"
+  version = "v1.1.0"
+
+[[projects]]
+  digest = "1:ade2df4d865299d2b042955eb4fdd9d60698b26cf3da10f1138a9bfefe9cd2c6"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = ""
+  revision = "7bc5445566f0fe75b15de23e6b93886e982d7bf9"
+  version = "v0.2.0"
+
+[[projects]]
+  digest = "1:7c55e3458cd4712634ca29163fd9bc7962a3dc9c361f58aa024cf422ce4a44dd"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
+  revision = "20c99e7aa07352b599bd0517cd5ca945f4af0407"
+  version = "v0.15.0"
+
+[[projects]]
+  digest = "1:d8ac5f1592931167d0e3fd8c6d81d62d2abfdde6d84dc0f21f00ddfbab753395"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/fs",
+    "internal/util",
+  ]
+  pruneopts = ""
+  revision = "9dece15c53cd5e9fbfbd72d5108adcf526a3f486"
+  version = "v0.2.0"
 
 [[projects]]
   digest = "1:a5274bdfcc63825d620dbd395605f5039a94c2af784907677cc589fca8b7a028"
@@ -173,6 +248,44 @@
   pruneopts = ""
   revision = "7db1c3b1a98089d0071c84f646ff5c96aad43682"
 
+[[projects]]
+  digest = "1:0d049ff01749ce1d6092c85cb90a02dfdb3b401939b13415b7e608f36bc8ecee"
+  name = "google.golang.org/protobuf"
+  packages = [
+    "encoding/prototext",
+    "encoding/protowire",
+    "internal/descfmt",
+    "internal/descopts",
+    "internal/detrand",
+    "internal/encoding/defval",
+    "internal/encoding/messageset",
+    "internal/encoding/tag",
+    "internal/encoding/text",
+    "internal/errors",
+    "internal/fieldsort",
+    "internal/filedesc",
+    "internal/filetype",
+    "internal/flags",
+    "internal/genid",
+    "internal/impl",
+    "internal/mapsort",
+    "internal/pragma",
+    "internal/set",
+    "internal/strs",
+    "internal/version",
+    "proto",
+    "reflect/protoreflect",
+    "reflect/protoregistry",
+    "runtime/protoiface",
+    "runtime/protoimpl",
+    "types/known/anypb",
+    "types/known/durationpb",
+    "types/known/timestamppb",
+  ]
+  pruneopts = ""
+  revision = "3f7a61f89bb6813f89d981d1870ed68da0b3c3f1"
+  version = "v1.25.0"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -186,6 +299,9 @@
     "github.com/docker/docker/pkg/jsonmessage",
     "github.com/docker/docker/pkg/stdcopy",
     "github.com/docker/go-units",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promauto",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/rakyll/statik/fs",
     "github.com/urfave/cli",
   ]

--- a/cmd/mistryd/main.go
+++ b/cmd/mistryd/main.go
@@ -190,7 +190,7 @@ func parseConfigFromCli(c *cli.Context) (*Config, error) {
 // StartServer sets up and spawns starts the HTTP server
 func StartServer(cfg *Config) error {
 	var wg sync.WaitGroup
-	s, err := NewServer(cfg, log.New(os.Stderr, "[http] ", log.LstdFlags))
+	s, err := NewServer(cfg, log.New(os.Stderr, "[http] ", log.LstdFlags), true)
 	if err != nil {
 		return err
 	}

--- a/cmd/mistryd/metrics/metrics.go
+++ b/cmd/mistryd/metrics/metrics.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -13,7 +14,13 @@ import (
 type Recorder struct {
 	Log *log.Logger
 
-	BuildsHosted *prometheus.GaugeVec
+	BuildsHosted                 *prometheus.GaugeVec
+	BuildsStarted                *prometheus.CounterVec
+	BuildsFinished               *prometheus.CounterVec
+	BuildsCoalesced              *prometheus.CounterVec
+	BuildsProcessedIncrementally *prometheus.CounterVec
+	BuildsSucceeded              *prometheus.HistogramVec
+	BuildsFailed                 *prometheus.HistogramVec
 }
 
 const namespace = "mistry"
@@ -28,6 +35,66 @@ func NewRecorder(logger *log.Logger) *Recorder {
 			Namespace: namespace,
 			Name:      "builds_hosted",
 			Help:      "The number of finished build hosted currently in the server",
+		},
+		[]string{"project"},
+	)
+
+	r.BuildsStarted = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "builds_started",
+			Help:      "The total number builds started by the server",
+		},
+		[]string{"project"},
+	)
+
+	r.BuildsFinished = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "builds_finished",
+			Help:      "The number of builds finished.",
+		},
+		[]string{"project"},
+	)
+
+	r.BuildsCoalesced = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "builds_coalesced",
+			Help:      "The number of builds that coalesced and were not processed",
+		},
+		[]string{"project"},
+	)
+
+	r.BuildsProcessedIncrementally = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "builds_processed_incrementally",
+			Help:      "The number builds processed incrementally by the server",
+		},
+		[]string{"project"},
+	)
+
+	// The buckets we create start at 2 minutes and we create 3 buckets of
+	// 2 minute intervals.
+	buildTimeBuckets := prometheus.LinearBuckets(120, 120, 3)
+
+	r.BuildsSucceeded = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "builds_succeeded_seconds",
+			Help:      "Build duration and count for successful results.",
+			Buckets:   buildTimeBuckets,
+		},
+		[]string{"project"},
+	)
+
+	r.BuildsFailed = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "builds_failed_seconds",
+			Help:      "Build duration and count for failed results.",
+			Buckets:   buildTimeBuckets,
 		},
 		[]string{"project"},
 	)
@@ -56,5 +123,38 @@ func (r *Recorder) RecordHostedBuilds(buildPath, projectsPath string) {
 
 		labels := prometheus.Labels{"project": project.Name()}
 		r.BuildsHosted.With(labels).Set(float64(len(builds)))
+	}
+}
+
+// RecordBuildStarted records a build started, independently from its outcome.
+func (r *Recorder) RecordBuildStarted(project string) {
+	r.BuildsStarted.With(prometheus.Labels{"project": project}).Inc()
+}
+
+// RecordBuildCoalesced records a project's build when coalesced.
+func (r *Recorder) RecordBuildCoalesced(project string) {
+	r.BuildsCoalesced.With(prometheus.Labels{"project": project}).Inc()
+}
+
+// RecordBuildFinished records a project's state, whether it was build incrementally
+// and tis duration.
+func (r *Recorder) RecordBuildFinished(
+	project string,
+	success bool,
+	incremental bool,
+	duration time.Duration,
+) {
+	labels := prometheus.Labels{"project": project}
+
+	r.BuildsFinished.With(labels).Inc()
+
+	if success {
+		if incremental {
+			r.BuildsProcessedIncrementally.With(labels).Inc()
+		}
+
+		r.BuildsSucceeded.With(labels).Observe(duration.Seconds())
+	} else {
+		r.BuildsFailed.With(labels).Observe(duration.Seconds())
 	}
 }

--- a/cmd/mistryd/metrics/metrics.go
+++ b/cmd/mistryd/metrics/metrics.go
@@ -21,6 +21,7 @@ type Recorder struct {
 	BuildsProcessedIncrementally *prometheus.CounterVec
 	BuildsSucceeded              *prometheus.HistogramVec
 	BuildsFailed                 *prometheus.HistogramVec
+	CacheUtilization             *prometheus.CounterVec
 }
 
 const namespace = "mistry"
@@ -99,6 +100,15 @@ func NewRecorder(logger *log.Logger) *Recorder {
 		[]string{"project"},
 	)
 
+	r.CacheUtilization = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "cache_utilization",
+			Help:      "Build result cache utilization",
+		},
+		[]string{"project"},
+	)
+
 	return r
 }
 
@@ -157,4 +167,9 @@ func (r *Recorder) RecordBuildFinished(
 	} else {
 		r.BuildsFailed.With(labels).Observe(duration.Seconds())
 	}
+}
+
+// RecordCacheUtilization records a project build's cache utilization.
+func (r *Recorder) RecordCacheUtilization(project string) {
+	r.CacheUtilization.With(prometheus.Labels{"project": project}).Inc()
 }

--- a/cmd/mistryd/metrics/metrics.go
+++ b/cmd/mistryd/metrics/metrics.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -10,11 +11,50 @@ import (
 
 // Recorder holds the collectors used by mistry to export data to prometheus.
 type Recorder struct {
+	Log *log.Logger
+
+	BuildsHosted *prometheus.GaugeVec
 }
 
+const namespace = "mistry"
+
 // NewRecorder initializes a Recorder and sets up the collectors.
-func NewRecorder() *Recorder {
+func NewRecorder(logger *log.Logger) *Recorder {
 	r := new(Recorder)
+	r.Log = logger
+
+	r.BuildsHosted = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "builds_hosted",
+			Help:      "The number of finished build hosted currently in the server",
+		},
+		[]string{"project"},
+	)
 
 	return r
+}
+
+// RecordHostedBuilds reads the number of builds for the project by counting
+// the folders under its directories.
+func (r *Recorder) RecordHostedBuilds(buildPath, projectsPath string) {
+	projects, err := ioutil.ReadDir(projectsPath)
+	if err != nil {
+		r.Log.Printf("Failed to read project directory: %s", projectsPath)
+
+		return
+	}
+
+	for _, project := range projects {
+		buildDir := fmt.Sprintf("%s/%s/ready", buildPath, project.Name())
+		builds, err := ioutil.ReadDir(buildDir)
+		if err != nil {
+			r.Log.Printf("Failed to read data directory: %s", buildDir)
+
+			continue
+		}
+
+		labels := prometheus.Labels{"project": project.Name()}
+		r.BuildsHosted.With(labels).Set(float64(len(builds)))
+	}
 }

--- a/cmd/mistryd/metrics/metrics.go
+++ b/cmd/mistryd/metrics/metrics.go
@@ -1,0 +1,20 @@
+package metrics
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Recorder holds the collectors used by mistry to export data to prometheus.
+type Recorder struct {
+}
+
+// NewRecorder initializes a Recorder and sets up the collectors.
+func NewRecorder() *Recorder {
+	r := new(Recorder)
+
+	return r
+}

--- a/cmd/mistryd/mistryd_test.go
+++ b/cmd/mistryd/mistryd_test.go
@@ -90,7 +90,7 @@ func TestMain(m *testing.M) {
 
 	logger = log.New(os.Stderr, "[http] ", log.LstdFlags)
 
-	server, err = NewServer(testcfg, logger)
+	server, err = NewServer(testcfg, logger, false)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/mistryd/server.go
+++ b/cmd/mistryd/server.go
@@ -56,7 +56,7 @@ type Server struct {
 // NewServer accepts a non-nil configuration and an optional logger, and
 // returns a new Server.
 // If logger is nil, server logs are disabled.
-func NewServer(cfg *Config, logger *log.Logger) (*Server, error) {
+func NewServer(cfg *Config, logger *log.Logger, enableMetrics bool) (*Server, error) {
 	var err error
 
 	if cfg == nil {
@@ -89,7 +89,11 @@ func NewServer(cfg *Config, logger *log.Logger) (*Server, error) {
 	s.pq = NewProjectQueue()
 	s.br = broker.NewBroker(s.Log)
 	s.workerPool = NewWorkerPool(s, cfg.Concurrency, cfg.Backlog, logger)
-	s.metrics = metrics.NewRecorder(logger)
+
+	if enableMetrics {
+		s.metrics = metrics.NewRecorder(logger)
+	}
+
 	return s, nil
 }
 

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -33,7 +33,9 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 	j.BuildInfo.URL = getJobURL(j)
 	j.BuildInfo.Group = j.Group
 
-	s.metrics.RecordBuildStarted(j.Project)
+	if s.metrics != nil {
+		s.metrics.RecordBuildStarted(j.Project)
+	}
 
 	// build coalescing
 	added := s.jq.Add(j)
@@ -58,7 +60,9 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 					j.BuildInfo.ExitCode = i
 					j.BuildInfo.Coalesced = true
 
-					s.metrics.RecordBuildCoalesced(j.Project)
+					if s.metrics != nil {
+						s.metrics.RecordBuildCoalesced(j.Project)
+					}
 
 					return j.BuildInfo, err
 				}
@@ -89,7 +93,10 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 			}
 		} else { // if a successful result already exists, use that
 			buildInfo.Cached = true
-			s.metrics.RecordCacheUtilization(j.Project)
+
+			if s.metrics != nil {
+				s.metrics.RecordCacheUtilization(j.Project)
+			}
 
 			return buildInfo, err
 		}
@@ -251,12 +258,14 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 	j.BuildInfo.ContainerStderr = outErr.String()
 	j.BuildInfo.Duration = time.Now().Sub(start).Truncate(time.Millisecond)
 
-	s.metrics.RecordBuildFinished(
-		j.Project,
-		j.BuildInfo.ExitCode == types.ContainerSuccessExitCode,
-		j.BuildInfo.Incremental,
-		j.BuildInfo.Duration,
-	)
+	if s.metrics != nil {
+		s.metrics.RecordBuildFinished(
+			j.Project,
+			j.BuildInfo.ExitCode == types.ContainerSuccessExitCode,
+			j.BuildInfo.Incremental,
+			j.BuildInfo.Duration,
+		)
+	}
 
 	log.Println("Finished after", j.BuildInfo.Duration)
 	return

--- a/cmd/mistryd/worker.go
+++ b/cmd/mistryd/worker.go
@@ -89,6 +89,8 @@ func (s *Server) Work(ctx context.Context, j *Job) (buildInfo *types.BuildInfo, 
 			}
 		} else { // if a successful result already exists, use that
 			buildInfo.Cached = true
+			s.metrics.RecordCacheUtilization(j.Project)
+
 			return buildInfo, err
 		}
 	} else if !os.IsNotExist(err) {

--- a/cmd/mistryd/worker_pool_test.go
+++ b/cmd/mistryd/worker_pool_test.go
@@ -56,7 +56,7 @@ func setupQueue(t *testing.T, workers, backlog int) (*WorkerPool, *Config) {
 	cfg.Concurrency = workers
 	cfg.Backlog = backlog
 
-	s, err := NewServer(cfg, nil)
+	s, err := NewServer(cfg, nil, false)
 	failIfError(err, t)
 	return s.workerPool, cfg
 }


### PR DESCRIPTION
This commit introduces a new class named `MetricsRecorder` and integrates with prometheus. Prometheus will pull the metrics every X seconds.

We have implemented:

* Builds on host
* Builds in general with state (success, failure, coalesce)
* Cache utilization
* Incremental utilization
* Build times

Closes #108